### PR TITLE
[WIP] Implement external interactions

### DIFF
--- a/Classes/Model/TGComment.h
+++ b/Classes/Model/TGComment.h
@@ -1,5 +1,5 @@
 //
-//  TGPostComment.h
+//  TGComment.h
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -21,7 +21,7 @@
 
 #import "TGReaction.h"
 
-@interface TGPostComment : TGReaction
+@interface TGComment : TGReaction
 
 /*!
  @abstract Content / text of the comment.

--- a/Classes/Model/TGComment.h
+++ b/Classes/Model/TGComment.h
@@ -28,4 +28,9 @@
  */
 @property (nonatomic, strong) NSString *content;
 
+/*!
+ @abstract Id of the external object.
+ */
+@property (nonatomic, strong) NSString *externalId;
+
 @end

--- a/Classes/Model/TGComment.m
+++ b/Classes/Model/TGComment.m
@@ -1,5 +1,5 @@
 //
-//  TGPostComment.m
+//  TGComment.m
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -18,10 +18,10 @@
 //  limitations under the License.
 //
 
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGObject+Private.h"
 
-@implementation TGPostComment
+@implementation TGComment
 
 - (NSDictionary*)jsonMapping {
     // left side: json attribute name , right side: model property name

--- a/Classes/Model/TGComment.m
+++ b/Classes/Model/TGComment.m
@@ -25,7 +25,10 @@
 
 - (NSDictionary*)jsonMapping {
     // left side: json attribute name , right side: model property name
-    return @{ @"content" : @"content" };
+    return @{
+             @"content" : @"content",
+             @"external_id" : @"externalId"
+             };
 }
 
 - (NSDictionary*)jsonMappingForWriting {

--- a/Classes/Model/TGLike.h
+++ b/Classes/Model/TGLike.h
@@ -1,5 +1,5 @@
 //
-//  TGPostLike.m
+//  TGLike.h
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -18,8 +18,8 @@
 //  limitations under the License.
 //
 
-#import "TGPostLike.h"
+#import "TGReaction.h"
 
-@implementation TGPostLike
+@interface TGLike : TGReaction
 
 @end

--- a/Classes/Model/TGLike.m
+++ b/Classes/Model/TGLike.m
@@ -1,5 +1,5 @@
 //
-//  TGPostLike.h
+//  TGLike.m
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -18,8 +18,8 @@
 //  limitations under the License.
 //
 
-#import "TGReaction.h"
+#import "TGLike.h"
 
-@interface TGPostLike : TGReaction
+@implementation TGLike
 
 @end

--- a/Classes/Model/TGPost+Reactions.h
+++ b/Classes/Model/TGPost+Reactions.h
@@ -20,7 +20,7 @@
 
 #import "TGPost.h"
 
-@class TGPostComment, TGPostLike;
+@class TGPostComment, TGLike;
 
 @interface TGPost (Reactions)
 
@@ -40,7 +40,7 @@
  @abstract Create a like on a post.
  @discussion Create a like on a post.
  */
-- (TGPostLike*)likeWithCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (TGLike*)likeWithCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Unlike a post.

--- a/Classes/Model/TGPost+Reactions.h
+++ b/Classes/Model/TGPost+Reactions.h
@@ -20,7 +20,7 @@
 
 #import "TGPost.h"
 
-@class TGPostComment, TGLike;
+@class TGComment, TGLike;
 
 @interface TGPost (Reactions)
 
@@ -32,7 +32,7 @@
  
  @param commentContent This contains the comment.
  */
-- (TGPostComment*)commentWithContent:(NSString*)commentContent withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (TGComment*)commentWithContent:(NSString*)commentContent withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 #pragma mark - Likes
 

--- a/Classes/Model/TGPost+Reactions.m
+++ b/Classes/Model/TGPost+Reactions.m
@@ -32,7 +32,7 @@
 
 #pragma mark - Likes
 
-- (TGPostLike*)likeWithCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+- (TGLike*)likeWithCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[Tapglue sharedInstance].postsManager createLikeForPost:self withCompletionBlock:completionBlock];
 }
 

--- a/Classes/Model/TGPost+Reactions.m
+++ b/Classes/Model/TGPost+Reactions.m
@@ -26,7 +26,7 @@
 
 #pragma mark - Comments
 
-- (TGPostComment*)commentWithContent:(NSString*)commentContent withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+- (TGComment*)commentWithContent:(NSString*)commentContent withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[Tapglue sharedInstance].postsManager createCommentWithContent:commentContent forPost:self withCompletionBlock:completionBlock];
 }
 

--- a/Classes/Model/TGPostComment.h
+++ b/Classes/Model/TGPostComment.h
@@ -19,9 +19,9 @@
 //
 //
 
-#import "TGPostReaction.h"
+#import "TGReaction.h"
 
-@interface TGPostComment : TGPostReaction
+@interface TGPostComment : TGReaction
 
 /*!
  @abstract Content / text of the comment.

--- a/Classes/Model/TGPostLike.h
+++ b/Classes/Model/TGPostLike.h
@@ -18,8 +18,8 @@
 //  limitations under the License.
 //
 
-#import "TGPostReaction.h"
+#import "TGReaction.h"
 
-@interface TGPostLike : TGPostReaction
+@interface TGPostLike : TGReaction
 
 @end

--- a/Classes/Model/TGReaction+Private.h
+++ b/Classes/Model/TGReaction+Private.h
@@ -1,5 +1,5 @@
 //
-//  TGPostReaction.h
+//  TGReaction+Private.h
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -19,9 +19,9 @@
 //
 
 
-#import "TGPostReaction.h"
+#import "TGReaction.h"
 
-@interface TGPostReaction (Private)
+@interface TGReaction (Private)
 
 @property (nonatomic, strong) TGUser *user;
 

--- a/Classes/Model/TGReaction.h
+++ b/Classes/Model/TGReaction.h
@@ -1,5 +1,5 @@
 //
-//  TGPostReaction.h
+//  TGReaction.h
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -25,7 +25,7 @@
 /*!
  @abstract The absract base class for reactions that the user can take on posts.
  */
-@interface TGPostReaction : TGModelObject
+@interface TGReaction : TGModelObject
 
 /*!
  @abstract User who performed the reaction on the post.

--- a/Classes/Model/TGReaction.m
+++ b/Classes/Model/TGReaction.m
@@ -1,5 +1,5 @@
 //
-//  TGPostReaction.h
+//  TGReaction.m
 //  Tapglue iOS SDK
 //
 //  Created by Martin Stemmle on 09/12/15.
@@ -18,28 +18,28 @@
 //  limitations under the License.
 //
 
-#import "TGPostReaction.h"
+#import "TGReaction.h"
 #import "TGUser+Private.h"
 #import "TGPost.h"
 #import "TGModelObject+Private.h"
 #import "NSDictionary+TGUtilities.h"
 
-static NSString *const TGPostReactionUserIdJsonKey = @"user_id";
-static NSString *const TGPostReactionPostIdJsonKey = @"post_id";
+static NSString *const TGReactionUserIdJsonKey = @"user_id";
+static NSString *const TGReactionPostIdJsonKey = @"post_id";
 
-@interface TGPostReaction ()
+@interface TGReaction ()
 @property (nonatomic, strong) TGUser *user;
 @property (nonatomic, strong) TGPost *post;
 @end
 
-@implementation TGPostReaction
+@implementation TGReaction
 
 #pragma mark - JSON Parsing
 
 - (void)loadDataFromDictionary:(NSDictionary *)data withMapping:(NSDictionary *)mapping {
     [super loadDataFromDictionary:data withMapping:mapping];
-    _user = [TGUser objectWithId:[data tg_stringValueForKey:TGPostReactionUserIdJsonKey]];
-    _post = [TGPost objectWithId:[data tg_stringValueForKey:TGPostReactionPostIdJsonKey]];
+    _user = [TGUser objectWithId:[data tg_stringValueForKey:TGReactionUserIdJsonKey]];
+    _post = [TGPost objectWithId:[data tg_stringValueForKey:TGReactionPostIdJsonKey]];
 }
 
 - (NSDictionary*)jsonMapping {

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -21,7 +21,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class TGPostComment, TGLike;
+@class TGComment, TGLike;
 
 @interface TGApiRoutesBuilder : NSObject
 
@@ -75,7 +75,7 @@
 
 + (NSString*)routeForCommentsOnPostWithId:(NSString*)postId;
 
-+ (NSString*)routeForComment:(TGPostComment*)comment;
++ (NSString*)routeForComment:(TGComment*)comment;
 + (NSString*)routeForCommentWithId:(NSString*)commentId onPostWithId:(NSString*)postId;
 
 + (NSString*)routeForLike:(TGLike*)like;

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -21,7 +21,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class TGPostComment, TGPostLike;
+@class TGPostComment, TGLike;
 
 @interface TGApiRoutesBuilder : NSObject
 
@@ -78,7 +78,7 @@
 + (NSString*)routeForComment:(TGPostComment*)comment;
 + (NSString*)routeForCommentWithId:(NSString*)commentId onPostWithId:(NSString*)postId;
 
-+ (NSString*)routeForLike:(TGPostLike*)like;
++ (NSString*)routeForLike:(TGLike*)like;
 + (NSString*)routeForLikesOnPostWithId:(NSString*)postId;
 
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId;

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -83,7 +83,11 @@
 
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId;
 
-#pragma mark - Likes
+#pragma mark - Comments -
+
++ (NSString*)routeForCommentOnObjectId:(NSString *)objectId;
+
+#pragma mark - Likes -
 
 + (NSString*)routeForLikeOnObjectId:(NSString *)objectId;
 

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -86,6 +86,7 @@
 #pragma mark - Comments -
 
 + (NSString*)routeForCommentOnObjectId:(NSString *)objectId;
++ (NSString*)routeForCommentWithId:(NSString*)commentId onObjectWithId:(NSString*)objectId;
 
 #pragma mark - Likes -
 

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -83,4 +83,8 @@
 
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId;
 
+#pragma mark - Likes
+
++ (NSString*)routeForLikeOnObjectId:(NSString *)objectId;
+
 @end

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -21,7 +21,7 @@
 #import "TGApiRoutesBuilder.h"
 #import "TGPost.h"
 #import "TGPostComment.h"
-#import "TGPostLike.h"
+#import "TGLike.h"
 
 static NSString * const TGApiRouteUsers = @"users";
 static NSString * const TGApiRouteCurrentUser = @"me";
@@ -88,7 +88,7 @@ static NSString * const TGApiRouteLikes = @"likes";
     return [[self routeForCommentsOnPostWithId:postId] stringByAppendingPathComponent:commentId];
 }
 
-+ (NSString*)routeForLike:(TGPostLike *)like {
++ (NSString*)routeForLike:(TGLike *)like {
     return [self routeForLikeWithId:like.objectId onPostWithId:like.post.objectId];
 }
 

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -101,7 +101,13 @@ static NSString * const TGApiRouteLikes = @"likes";
     return [[self routeForLikesOnPostWithId:postId] stringByAppendingPathComponent:likeId];
 }
 
-#pragma mark - Likes
+#pragma mark - Comments -
+
++ (NSString*)routeForCommentOnObjectId:(NSString *)objectId {
+    return [[TGApiRouteExternals stringByAppendingPathComponent:objectId] stringByAppendingPathComponent:TGApiRouteComments];
+}
+
+#pragma mark - Likes -
 
 + (NSString*)routeForLikeOnObjectId:(NSString *)objectId {
     return [[TGApiRouteExternals stringByAppendingPathComponent:objectId] stringByAppendingPathComponent:TGApiRouteLikes];

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -20,7 +20,7 @@
 
 #import "TGApiRoutesBuilder.h"
 #import "TGPost.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGLike.h"
 
 static NSString * const TGApiRouteUsers = @"users";
@@ -79,7 +79,7 @@ static NSString * const TGApiRouteLikes = @"likes";
     return [[self routeForPostWithId:postId] stringByAppendingPathComponent:TGApiRouteComments];
 }
 
-+ (NSString*)routeForComment:(TGPostComment *)comment {
++ (NSString*)routeForComment:(TGComment *)comment {
     return [self routeForCommentWithId:comment.objectId onPostWithId:comment.post.objectId];
 }
             

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -28,6 +28,7 @@ static NSString * const TGApiRouteCurrentUser = @"me";
 static NSString * const TGApiRouteFeed = @"feed";
 static NSString * const TGApiRoutePosts = @"posts";
 static NSString * const TGApiRouteEvents = @"events";
+static NSString * const TGApiRouteExternals = @"externals";
 static NSString * const TGApiRouteComments = @"comments";
 static NSString * const TGApiRouteLikes = @"likes";
 
@@ -98,6 +99,12 @@ static NSString * const TGApiRouteLikes = @"likes";
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId {
     NSParameterAssert(likeId);
     return [[self routeForLikesOnPostWithId:postId] stringByAppendingPathComponent:likeId];
+}
+
+#pragma mark - Likes
+
++ (NSString*)routeForLikeOnObjectId:(NSString *)objectId {
+    return [[[self baseRouteForFeeds] stringByAppendingPathComponent:TGApiRouteExternals] stringByAppendingPathComponent:objectId];
 }
 
 #pragma mark - Helper 

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -104,7 +104,7 @@ static NSString * const TGApiRouteLikes = @"likes";
 #pragma mark - Likes
 
 + (NSString*)routeForLikeOnObjectId:(NSString *)objectId {
-    return [[[self baseRouteForFeeds] stringByAppendingPathComponent:TGApiRouteExternals] stringByAppendingPathComponent:objectId];
+    return [[TGApiRouteExternals stringByAppendingPathComponent:objectId] stringByAppendingPathComponent:TGApiRouteLikes];
 }
 
 #pragma mark - Helper 

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -107,6 +107,9 @@ static NSString * const TGApiRouteLikes = @"likes";
     return [[TGApiRouteExternals stringByAppendingPathComponent:objectId] stringByAppendingPathComponent:TGApiRouteComments];
 }
 
++ (NSString*)routeForCommentWithId:(NSString*)commentId onObjectWithId:(NSString*)objectId {
+    return [[[TGApiRouteExternals stringByAppendingPathComponent:objectId] stringByAppendingPathComponent:TGApiRouteComments] stringByAppendingPathComponent:commentId];
+}
 #pragma mark - Likes -
 
 + (NSString*)routeForLikeOnObjectId:(NSString *)objectId {

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -176,6 +176,12 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  */
 -(TGPostComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Deletes a comment on a custom object.
+ @discussion This will delete a comment on a custom object.
+ */
+-(void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 #pragma mark - Likes -
 
 /*!

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -174,13 +174,13 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  @abstract Creates a comment on a custom object.
  @discussion This will create a comment on a custom object.
  */
--(TGPostComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+-(TGComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Deletes a comment on a custom object.
  @discussion This will delete a comment on a custom object.
  */
--(void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+-(void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 #pragma mark - Likes -
 

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -182,4 +182,10 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  */
 - (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Retrieves like events on a custom object.
+ @discussion This will retrieve like events on a custom object.
+ */
+- (void)retrieveLikesForObjectWithId:(NSString*)objectId andCompletionBlock:(void (^)(NSArray *Likes, NSError *error))completionBlock;
+
 @end

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -168,4 +168,12 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  */
 - (void)retrieveFeedUnreadCountForCurrentWithCompletionBlock:(void (^)(NSInteger, NSError *))completionBlock;
 
+#pragma mark - Likes
+
+/*!
+ @abstract Create a like event on a custom object.
+ @discussion This will create a like event on a custom object.
+ */
+- (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 @end

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -176,4 +176,10 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  */
 - (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Delete a like event on a custom object.
+ @discussion This will delete a like event on a custom object.
+ */
+- (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 @end

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -174,13 +174,19 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  @abstract Creates a comment on a custom object.
  @discussion This will create a comment on a custom object.
  */
--(TGComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (TGComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Deletes a comment on a custom object.
  @discussion This will delete a comment on a custom object.
  */
--(void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
+/*!
+ @abstract Retrieve all comment on an objectId.
+ @discussion This will retrieve all comments on an objectId.
+ */
+- (void)retrieveCommentsForObjectWithId:objectId withCompletionBlock:(void (^)(NSArray *comments, NSError *error))completionBlock;
 
 #pragma mark - Likes -
 

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -177,6 +177,14 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
 - (TGComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
+ @abstract Updates a comment on an objectId.
+ @discussion This will update a comment on an objectId.
+ 
+ @param comment The comment object that is being updated.
+ */
+- (void)updateComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
+/*!
  @abstract Deletes a comment on a custom object.
  @discussion This will delete a comment on a custom object.
  */

--- a/Classes/TGEventManager.h
+++ b/Classes/TGEventManager.h
@@ -168,7 +168,15 @@ extern NSString *const TGEventManagerAPIEndpointEvents;
  */
 - (void)retrieveFeedUnreadCountForCurrentWithCompletionBlock:(void (^)(NSInteger, NSError *))completionBlock;
 
-#pragma mark - Likes
+#pragma mark - Comments -
+
+/*!
+ @abstract Creates a comment on a custom object.
+ @discussion This will create a comment on a custom object.
+ */
+-(TGPostComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
+#pragma mark - Likes -
 
 /*!
  @abstract Create a like event on a custom object.

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -27,7 +27,7 @@
 #import "TGLogger.h"
 #import "Tapglue+Private.h"
 #import "TGUserManager.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGApiRoutesBuilder.h"
 
 NSString *const TGEventManagerAPIEndpointEvents = @"events";
@@ -260,9 +260,9 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
 
 #pragma mark - Comments -
 
--(TGPostComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+-(TGComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     NSString *route = [TGApiRoutesBuilder routeForCommentOnObjectId:objectId];
-    TGPostComment *objectComment = [[TGPostComment alloc] init];
+    TGComment *objectComment = [[TGComment alloc] init];
     objectComment.content = comment;
     
     [self.client POST:route withURLParameters:nil andPayload:objectComment.jsonDictionary andCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
@@ -279,7 +279,7 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     return objectComment;
 }
 
--(void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+-(void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     NSString *route = [TGApiRoutesBuilder routeForCommentWithId:comment.objectId onObjectWithId:objectId];
     [self.client DELETE:route withCompletionBlock:completionBlock];
 }

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -27,6 +27,7 @@
 #import "TGLogger.h"
 #import "Tapglue+Private.h"
 #import "TGUserManager.h"
+#import "TGPostComment.h"
 #import "TGApiRoutesBuilder.h"
 
 NSString *const TGEventManagerAPIEndpointEvents = @"events";
@@ -257,7 +258,28 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     [self retrieveEventWithId:eventId forUserWithID:nil withCompletionBlock:completionBlock];
 }
 
-#pragma mark Likes
+#pragma mark - Comments -
+
+-(TGPostComment*)createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForCommentOnObjectId:objectId];
+    TGPostComment *objectComment = [[TGPostComment alloc] init];
+    objectComment.content = comment;
+    
+    [self.client POST:route withURLParameters:nil andPayload:objectComment.jsonDictionary andCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
+        [objectComment loadDataFromDictionary:jsonResponse]; // update the data
+        if (!error) {
+            if (completionBlock) {
+                completionBlock(YES, nil);
+            }
+        } else if (completionBlock) {
+            completionBlock(NO, error);
+        }
+    }];
+    
+    return objectComment;
+}
+
+#pragma mark - Likes -
 
 - (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     NSString *route = [TGApiRoutesBuilder routeForLikeOnObjectId:objectId];

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -279,6 +279,11 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     return objectComment;
 }
 
+-(void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForCommentWithId:comment.objectId onObjectWithId:objectId];
+    [self.client DELETE:route withCompletionBlock:completionBlock];
+}
+
 #pragma mark - Likes -
 
 - (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -257,7 +257,20 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     [self retrieveEventWithId:eventId forUserWithID:nil withCompletionBlock:completionBlock];
 }
 
+#pragma mark Likes
 
+- (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForLikeOnObjectId:objectId];
+    [self.client POST:route withURLParameters:nil andPayload:nil andCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
+        if (!error) {
+            if (completionBlock) {
+                completionBlock(YES, nil);
+            }
+        } else if (completionBlock) {
+            completionBlock(NO, error);
+        }
+    }];
+}
 
 #pragma mark collection
 

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -272,6 +272,19 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     }];
 }
 
+- (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForLikeOnObjectId:objectId];
+    [self.client DELETE:route withCompletionBlock:^(BOOL success, NSError *error) {
+        if (!error) {
+            if (completionBlock) {
+                completionBlock(YES, nil);
+            }
+        } else if (completionBlock) {
+            completionBlock(NO, error);
+        }
+    }];
+}
+
 #pragma mark collection
 
 

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -285,6 +285,30 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     }];
 }
 
+- (void)retrieveLikesForObjectWithId:(NSString*)objectId andCompletionBlock:(void (^)(NSArray *Likes, NSError *error))completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForLikeOnObjectId:objectId];
+    [self.client GET:route withURLParameters:nil andCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
+        
+        if (!error) {
+            NSArray *userDictionaries = [[jsonResponse objectForKey:@"users"] allValues];
+            [TGUser createAndCacheObjectsFromDictionaries:userDictionaries];
+            
+            NSArray *likeDictionaries = [jsonResponse objectForKey:@"likes"];
+            NSMutableArray *likes = [NSMutableArray arrayWithCapacity:likeDictionaries.count];
+            for (NSDictionary *data in likeDictionaries) {
+                [likes addObject:[[TGPostLike alloc] initWithDictionary:data]];
+            }
+            
+            if (completionBlock) {
+                completionBlock(likes, nil);
+            }
+        }
+        else if(completionBlock) {
+            completionBlock(nil, error);
+        }
+    }];
+}
+
 #pragma mark collection
 
 

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -281,6 +281,15 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
     return objectComment;
 }
 
+- (void)updateComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForCommentWithId:comment.objectId onObjectWithId:objectId];
+    [self.client PUT:route withURLParameters:nil andPayload:comment.jsonDictionary andCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
+        if (completionBlock) {
+            completionBlock(error == nil, error);
+        }
+    }];
+}
+
 - (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     NSString *route = [TGApiRoutesBuilder routeForCommentWithId:comment.objectId onObjectWithId:objectId];
     [self.client DELETE:route withCompletionBlock:completionBlock];

--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -323,7 +323,7 @@ NSString *const TGEventManagerAPIEndpointEvents = @"events";
             NSArray *likeDictionaries = [jsonResponse objectForKey:@"likes"];
             NSMutableArray *likes = [NSMutableArray arrayWithCapacity:likeDictionaries.count];
             for (NSDictionary *data in likeDictionaries) {
-                [likes addObject:[[TGPostLike alloc] initWithDictionary:data]];
+                [likes addObject:[[TGLike alloc] initWithDictionary:data]];
             }
             
             if (completionBlock) {

--- a/Classes/TGPostsManager.h
+++ b/Classes/TGPostsManager.h
@@ -21,7 +21,7 @@
 #import "TGBaseManager.h"
 #import "TGConstants.h"
 
-@class TGUser, TGPost, TGPostComment, TGPostLike;
+@class TGUser, TGPost, TGPostComment, TGLike;
 
 @interface TGPostsManager : TGBaseManager
 
@@ -101,7 +101,7 @@
 
 #pragma mark - Likes
 
-- (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 - (void)deleteLike:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 

--- a/Classes/TGPostsManager.h
+++ b/Classes/TGPostsManager.h
@@ -21,7 +21,7 @@
 #import "TGBaseManager.h"
 #import "TGConstants.h"
 
-@class TGUser, TGPost, TGPostComment, TGLike;
+@class TGUser, TGPost, TGComment, TGLike;
 
 @interface TGPostsManager : TGBaseManager
 
@@ -88,13 +88,13 @@
 
 #pragma mark - Comments -
 
-- (TGPostComment*)createCommentWithContent:(NSString*)commentContent
+- (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
-- (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
-- (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+- (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 - (void)retrieveCommentsForPostWithId:(NSString*)postId
                   withCompletionBlock:(void (^)(NSArray *comments, NSError *error))completionBlock;

--- a/Classes/TGPostsManager.m
+++ b/Classes/TGPostsManager.m
@@ -26,7 +26,7 @@
 #import "NSError+TGError.h"
 #import "TGObjectCache.h"
 #import "TGApiRoutesBuilder.h"
-#import "TGPostReaction+Private.h"
+#import "TGReaction+Private.h"
 #import "TGPostComment.h"
 #import "TGPostLike.h"
 

--- a/Classes/TGPostsManager.m
+++ b/Classes/TGPostsManager.m
@@ -28,7 +28,7 @@
 #import "TGApiRoutesBuilder.h"
 #import "TGReaction+Private.h"
 #import "TGPostComment.h"
-#import "TGPostLike.h"
+#import "TGLike.h"
 
 @implementation TGPostsManager
 
@@ -173,8 +173,8 @@
 
 #pragma mark - Likes -
 
-- (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
-    TGPostLike *like = [[TGPostLike alloc] init];
+- (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    TGLike *like = [[TGLike alloc] init];
     like.post = post;
     like.user = [TGUser currentUser];
     
@@ -207,7 +207,7 @@
             NSArray *likeDictionaries = [jsonResponse objectForKey:@"likes"];
             NSMutableArray *likes = [NSMutableArray arrayWithCapacity:likeDictionaries.count];
             for (NSDictionary *data in likeDictionaries) {
-                [likes addObject:[[TGPostLike alloc] initWithDictionary:data]];
+                [likes addObject:[[TGLike alloc] initWithDictionary:data]];
             }
             
             if (completionBlock) {

--- a/Classes/TGPostsManager.m
+++ b/Classes/TGPostsManager.m
@@ -27,7 +27,7 @@
 #import "TGObjectCache.h"
 #import "TGApiRoutesBuilder.h"
 #import "TGReaction+Private.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGLike.h"
 
 @implementation TGPostsManager
@@ -121,11 +121,11 @@
 
 #pragma mark - Comments -
 
-- (TGPostComment*)createCommentWithContent:(NSString*)commentContent
+- (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     
-    TGPostComment *comment = [[TGPostComment alloc] init];
+    TGComment *comment = [[TGComment alloc] init];
     comment.content = commentContent;
     comment.post = post;
     comment.user = [TGUser currentUser];
@@ -137,13 +137,13 @@
     return comment;
 }
 
-- (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+- (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [self.client updateObject:comment
                       atRoute:[TGApiRoutesBuilder routeForComment:comment]
           withCompletionBlock:completionBlock];
 }
 
-- (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+- (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [self.client DELETE:[TGApiRoutesBuilder routeForComment:comment] withCompletionBlock:completionBlock];
 }
 
@@ -158,7 +158,7 @@
             NSArray *commentDictionaries = [jsonResponse objectForKey:@"comments"];
             NSMutableArray *comments = [NSMutableArray arrayWithCapacity:commentDictionaries.count];
             for (NSDictionary *data in commentDictionaries) {
-                [comments addObject:[[TGPostComment alloc] initWithDictionary:data]];
+                [comments addObject:[[TGComment alloc] initWithDictionary:data]];
             }
 
             if (completionBlock) {

--- a/Classes/Tapglue+Posts.h
+++ b/Classes/Tapglue+Posts.h
@@ -22,7 +22,7 @@
 #import "TGPost.h"
 #import "TGPost+Reactions.h"
 #import "TGAttachment.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGLike.h"
 
 @interface Tapglue (Posts)
@@ -113,7 +113,7 @@
  @param commentContent The content of the comment.
  @param post The Post object that is being commented.
  */
-+ (TGPostComment*)createCommentWithContent:(NSString*)commentContent
++ (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
@@ -123,7 +123,7 @@
  
  @param comment The comment object that is being updated.
  */
-+ (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Deletes a comment on a post.
@@ -131,7 +131,7 @@
  
  @param comment The comment object that is being deleted.
  */
-+ (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Retrieve comments for a post.

--- a/Classes/Tapglue+Posts.h
+++ b/Classes/Tapglue+Posts.h
@@ -23,7 +23,7 @@
 #import "TGPost+Reactions.h"
 #import "TGAttachment.h"
 #import "TGPostComment.h"
-#import "TGPostLike.h"
+#import "TGLike.h"
 
 @interface Tapglue (Posts)
 
@@ -159,7 +159,7 @@
  
  @param post The post object for which a like is being created.
  */
-+ (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Delete a like for a post.

--- a/Classes/Tapglue+Posts.m
+++ b/Classes/Tapglue+Posts.m
@@ -109,7 +109,7 @@
 
 #pragma mark - Likes -
 
-+ (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[self postsManager] createLikeForPost:post withCompletionBlock:completionBlock];
 }
 

--- a/Classes/Tapglue+Posts.m
+++ b/Classes/Tapglue+Posts.m
@@ -82,17 +82,17 @@
 
 #pragma mark - Comments -
 
-+ (TGPostComment*)createCommentWithContent:(NSString*)commentContent
++ (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[self postsManager] createCommentWithContent:commentContent forPost:post withCompletionBlock:completionBlock];
 }
 
-+ (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [[self postsManager] updateComment:comment withCompletionBlock:completionBlock];
 }
 
-+ (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [[self postsManager] deleteComment:comment withCompletionBlock:completionBlock];
 }
 

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -556,6 +556,18 @@
  */
 + (void)retrieveNewsFeedForCurrentUserForEventTypes:(NSArray*)types withCompletionBlock:(TGGetNewsFeedCompletionBlock)completionBlock;
 
+#pragma mark Comments
+
+#pragma mark Likes
+
+/*!
+ @abstract Create a like for an objectId.
+ @discussion This will create a like for an objectId.
+ 
+ @param objectId The objectId for which a like is being created.
+ */
++ (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 #pragma mark - Raw Rest -
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -576,6 +576,15 @@
  */
 + (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Retrieve likes for an objectId.
+ @discussion This will retrieve all likes for a objectId.
+ 
+ @param objectI The objectId for which likes are retrieved.
+ */
++ (void)retrieveLikesForObjectWithId:(NSString*)objectId
+               withCompletionBlock:(void (^)(NSArray *likes, NSError *error))completionBlock;
+
 #pragma mark - Raw Rest -
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -570,6 +570,14 @@
                                    forObjectWithId:(NSString*)objectId
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Deletes a comment for an objectId.
+ @discussion This will delete a comment for an objectId.
+ 
+ @param objectId The objectId for which a comment is being deleted.
+ */
++ (void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 #pragma mark Likes
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -23,6 +23,7 @@
 #import "TGUser+Networking.h"
 #import "TGEvent+Networking.h"
 #import "TGEventObject.h"
+#import "TGPostComment.h"
 #import "TGConnection.h"
 #import "TGConfiguration.h"
 #import "TGQuery.h"
@@ -557,6 +558,17 @@
 + (void)retrieveNewsFeedForCurrentUserForEventTypes:(NSArray*)types withCompletionBlock:(TGGetNewsFeedCompletionBlock)completionBlock;
 
 #pragma mark Comments
+
+/*!
+ @abstract Creates a comment on a custom objectId.
+ @discussion This will create a comment on an objectId.
+ 
+ @param comment The content of the comment.
+ @param post The Post object that is being commented.
+ */
++ (TGPostComment*)createComment:(NSString*)comment
+                                   forObjectWithId:(NSString*)objectId
+                       withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 #pragma mark Likes
 

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -23,7 +23,7 @@
 #import "TGUser+Networking.h"
 #import "TGEvent+Networking.h"
 #import "TGEventObject.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGConnection.h"
 #import "TGConfiguration.h"
 #import "TGQuery.h"
@@ -566,7 +566,7 @@
  @param comment The content of the comment.
  @param post The Post object that is being commented.
  */
-+ (TGPostComment*)createComment:(NSString*)comment
++ (TGComment*)createComment:(NSString*)comment
                                    forObjectWithId:(NSString*)objectId
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
@@ -576,7 +576,7 @@
  
  @param objectId The objectId for which a comment is being deleted.
  */
-+ (void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 #pragma mark Likes
 

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -568,6 +568,14 @@
  */
 + (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Deletes a like for an objectId.
+ @discussion This will delete a like for an objectId.
+ 
+ @param objectId The objectId for which a like is being deleted.
+ */
++ (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
 #pragma mark - Raw Rest -
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -578,6 +578,15 @@
  */
 + (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
+/*!
+ @abstract Retrieve comments for an objectId.
+ @discussion This will retrieve all comments for an objectId.
+ 
+ @param objectId The objectId for which comments are retrieved.
+ */
++ (void)retrieveCommentsForObjectWithId:(NSString*)objectId
+                  withCompletionBlock:(void (^)(NSArray *comments, NSError *error))completionBlock;
+
 #pragma mark Likes
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -571,6 +571,14 @@
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
+ @abstract Updates a comment on an objectId.
+ @discussion This will update a comment on a objectId.
+ 
+ @param comment The comment object that is being updated.
+ */
++ (void)updateComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+
+/*!
  @abstract Deletes a comment for an objectId.
  @discussion This will delete a comment for an objectId.
  

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -610,6 +610,11 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
 }
 
++ (void)retrieveCommentsForObjectWithId:(NSString*)objectId
+                    withCompletionBlock:(void (^)(NSArray *comments, NSError *error))completionBlock {
+    [[self sharedInstance].eventManager retrieveCommentsForObjectWithId:objectId withCompletionBlock:completionBlock];
+}
+
 #pragma mark - Likes -
 
 + (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -598,6 +598,12 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager retrieveNewsFeedForCurrentUserWithQuery:query andCompletionBlock:completionBlock];
 }
 
+#pragma mark - Likes -
+
++ (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    [[self sharedInstance].eventManager createLikeForObjectWithId:objectId andCompletionBlock:completionBlock];
+}
+
 #pragma mark - Raw Rest -
 
 + (NSURLSessionDataTask*) makeRestRequestWithHTTPMethod:(NSString*)method

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -598,6 +598,14 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager retrieveNewsFeedForCurrentUserWithQuery:query andCompletionBlock:completionBlock];
 }
 
+#pragma mark - Comments -
+
++ (TGPostComment*)createComment:(NSString*)comment
+      forObjectWithId:(NSString*)objectId
+  withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    return [[self sharedInstance].eventManager createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:completionBlock];
+}
+
 #pragma mark - Likes -
 
 + (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -606,6 +606,10 @@ static Tapglue* sharedInstance = nil;
     return [[self sharedInstance].eventManager createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:completionBlock];
 }
 
++ (void)updateComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    [[self sharedInstance].eventManager updateComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
+}
+
 + (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [[self sharedInstance].eventManager deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
 }

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -604,6 +604,10 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager createLikeForObjectWithId:objectId andCompletionBlock:completionBlock];
 }
 
++ (void)deleteLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    [[self sharedInstance].eventManager deleteLikeForObjectWithId:objectId andCompletionBlock:completionBlock];
+}
+
 #pragma mark - Raw Rest -
 
 + (NSURLSessionDataTask*) makeRestRequestWithHTTPMethod:(NSString*)method

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -606,6 +606,10 @@ static Tapglue* sharedInstance = nil;
     return [[self sharedInstance].eventManager createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:completionBlock];
 }
 
++ (void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    [[self sharedInstance].eventManager deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
+}
+
 #pragma mark - Likes -
 
 + (void)createLikeForObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -608,6 +608,11 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager deleteLikeForObjectWithId:objectId andCompletionBlock:completionBlock];
 }
 
++ (void)retrieveLikesForObjectWithId:(NSString*)objectId
+                 withCompletionBlock:(void (^)(NSArray *likes, NSError *error))completionBlock {
+    [[self sharedInstance].eventManager retrieveLikesForObjectWithId:objectId andCompletionBlock:completionBlock];
+}
+
 #pragma mark - Raw Rest -
 
 + (NSURLSessionDataTask*) makeRestRequestWithHTTPMethod:(NSString*)method

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -600,14 +600,14 @@ static Tapglue* sharedInstance = nil;
 
 #pragma mark - Comments -
 
-+ (TGPostComment*)createComment:(NSString*)comment
++ (TGComment*)createComment:(NSString*)comment
       forObjectWithId:(NSString*)objectId
   withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[self sharedInstance].eventManager createComment:(NSString*)comment forObjectWithId:objectId andCompletionBlock:completionBlock];
 }
 
-+ (void)deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
-    [[self sharedInstance].eventManager deleteComment:(TGPostComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
++ (void)deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:(TGSucessCompletionBlock)completionBlock {
+    [[self sharedInstance].eventManager deleteComment:(TGComment*)comment forObjectWithId:(NSString*)objectId andCompletionBlock:completionBlock];
 }
 
 #pragma mark - Likes -

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Simply call `setUpWithAppToken: andConfig:` and define a config like in the foll
 
 // Create config object
 TGConfiguration *customConfig = [TGConfiguration defaultConfiguration];
-    
+
 // Configure custom settings
 customConfig.loggingEnabled = true;
-    
+
 // Initialize the SDK with app token and config
 [Tapglue setUpWithAppToken:tapglueToken andConfig:customConfig];
 ```
@@ -160,7 +160,7 @@ When you successfully create or login a user, we store it as the `currentUser` b
 
 ```objective-c
 TGUser *user = [[TGUser alloc] init];
-    
+
 if (user.isCurrentUser) {
     // User is currentUser
 } else {
@@ -180,7 +180,7 @@ If users want to update their profile information you can update it with the `sa
 
 ```objective-c
 TGUser *user = [TGUser currentUser]
-        
+
 user.username = @"changedUsername";
 [user saveWithCompletionBlock:^(BOOL success, NSError *error) {
 	if (success) {
@@ -197,7 +197,7 @@ To delete the current user you can perform `deleteWithCompletionBlock`.
 
 ```objective-c
 TGUser *user = [TGUser currentUser]
-        
+
 [user deleteWithCompletionBlock:^(BOOL success, NSError *error) {
 	if (success) {
   	// Implement success after login.
@@ -235,7 +235,7 @@ If you want to search for multiple e-mails and get back a list of users. This is
 ```objective-c
 // Specify list of emails
 NSArray *emails = @[@"user@mail.com", @"user2@mail.com"];
-        
+
 // Search users
 [Tapglue searchUsersWithEmails:emails andCompletionBlock:^(NSArray *users, NSError *error) {
     if users != nil && error == nil {
@@ -253,7 +253,7 @@ A similar behaviour can be achieved if you want to sync users from another netwo
 ```objective-c
 // Specify list of socialIds
 NSArray *socialIds = @[@"1234567", @"7654321"];
-        
+
 // Search users
 [Tapglue searchUsersOnSocialPlatform:TGPlatformKeyFacebook withSocialUsersIds:socialIds andCompletionBlock:^(NSArray *users, NSError *error) {
     if users != nil && error == nil {
@@ -307,10 +307,10 @@ NSArray *friendsIds = ... // retrieve users
          onPlatfromWithSocialIdKey:@"twitter"
                withCompletionBlock:^(BOOL success, NSError *error) {
                    if (success) {
-                        // friends added successfully 
+                        // friends added successfully
                    }
                    else {
-                        // Error handling 
+                        // Error handling
                    }
                }];
 ```
@@ -324,18 +324,18 @@ Here is a concrete example, of how to fetch friends from the Facebook SDK:
 FBSDKGraphRequest *myFriendsRequest = [[FBSDKGraphRequest alloc] initWithGraphPath:@"me/friends" parameters:nil];
 
 [myFriendsRequest startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
-        
+
     if (result && !error) {
         // request succeeded > found frined
-        NSArray *friendsIds = [result valueForKeyPath:@"data.id"]; 
+        NSArray *friendsIds = [result valueForKeyPath:@"data.id"];
         [Tapglue friendUsersWithSocialsIds:friendsIds
                  onPlatfromWithSocialIdKey:TGUserSocialIdFacebookKey
                        withCompletionBlock:^(BOOL success, NSError *error) {
                            if (success) {
-                                // friends added successfully 
+                                // friends added successfully
                            }
                            else {
-                                // Error Handling 
+                                // Error Handling
                            }
                        }];           
     } else {
@@ -384,37 +384,37 @@ In the last example you create a `TGEvent` object first that creates all informa
 ```objective-c
 // Create TGEvent object
 TGEvent *event = [[TGEvent alloc] init];
-    
+
 event.type = @"like";
 event.language = @"en";
 event.location = @"berlin";
 event.latitude = 52.520007;
 event.longitude = 13.404954;
-    
+
 // Create object
 TGEventObject *object = [[TGEventObject alloc] init];
-    
+
 object.objectId = @"article_123";
 object.type = @"article";
 object.url = @"app://articles/article_123";
 [object setDisplayName:@"article title" forLanguage:@"en"];
 [object setDisplayName:@"artikel titel" forLanguage:@"de"];
-    
+
 event.object = object;
-    
+
 event.metadata = @{
                    @"foo" : @"bar",
                    @"amount" : @12,
                    @"progress" : @0.95
    	               };
-    
+
 // Send event
 [Tapglue createEvent:event];
 ```
 
 ## Event visibilities
 
-Besides the attributes that you attach to each event, you can specify different visibilities. Those 
+Besides the attributes that you attach to each event, you can specify different visibilities. Those
 
 - `TGVisibility.Private`
 - `TGVisibility.Connection`
@@ -446,17 +446,17 @@ In the last example you create a `TGPost` object first that creates all informat
 TGPost *post = [TGPost new];
 post.visibility = TGVisibilityPublic;
 post.tags = @[@"fitness",@"running"];
-        
+
 // Create Attachment
 [post addAttachment:[TGAttachment attachmentWithText:@"This is the Text of the Post." andName:@"body"]];
-        
+
 // Create Post
 [Tapglue createPost:post withCompletionBlock:^(BOOL success, NSError *error) {
 		if (success) {
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -492,7 +492,7 @@ NSString *comment = @"This is the comment of the post.";
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -512,7 +512,7 @@ The first one requires a post object, the second one a `postId` only. Comments c
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -543,7 +543,7 @@ The first option is the main method to create a like. This requires to pass the 
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -563,7 +563,7 @@ Simply run the following to retrieve them:
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -580,7 +580,7 @@ If a user unlikes a post again, use following method:
 			// Success handling
 		}
 		else {
-			// Error handling 
+			// Error handling
 		}
 }];
 ```
@@ -799,7 +799,7 @@ You can turn on Tapglue logging by initialising the SDK with a custom configurat
 ```objective-c
 // Create config object
 TGConfiguration *customConfig = [TGConfiguration defaultConfiguration];
-    
+
 // Configure custom settings
 customConfig.loggingEnabled = true;
 ```
@@ -826,3 +826,7 @@ Most methods will provide you either a value or an error. We recommend to always
 
 This SDK is provided under Apache 2.0 license. For the full license, please see the [LICENSE](LICENSE) file that
 ships with this SDK.
+
+# PR
+
+TODO: Implement Comments & Likes on external objects

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1172,4 +1172,20 @@
     }];
 }
 
+// [Correct] Create a comment on a custom object
+- (void)testCreateCommentOnObjectId {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        NSString *objectId = [NSString randomStringWithLength:5];
+        NSString *comment = [NSString randomStringWithLength:10];
+        
+        [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
+            expect(success).to.beTruthy();
+            expect(error).to.beNil();
+            
+            [expectation fulfill];
+        }];
+    }];
+}
+
 @end

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1195,17 +1195,22 @@
         NSString *objectId = [NSString randomStringWithLength:5];
         NSString *comment = [NSString randomStringWithLength:10];
         
-        TGComment* objectComment = [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
+        [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
             expect(success).to.beTruthy();
             expect(error).to.beNil();
             
-            NSLog(@"CommentId = %@", objectComment.objectId);
-            
-            [Tapglue deleteComment:objectComment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+            [Tapglue retrieveCommentsForObjectWithId:objectId withCompletionBlock:^(NSArray *comments, NSError *error) {
                 expect(success).to.beTruthy();
                 expect(error).to.beNil();
                 
-                [expectation fulfill];
+                TGComment *comment = comments.firstObject;
+                
+                [Tapglue deleteComment:comment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                    expect(success).to.beTruthy();
+                    expect(error).to.beNil();
+                    
+                    [expectation fulfill];
+                }];iter
             }];
         }];
     }];

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1189,7 +1189,7 @@
 }
 
 // [Correct] Delete a comment on a custom object
-- (void)testDeleteCommentOnObjectId {
+- (void)testCRUDCommentOnObjectId {
     [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
         
         NSString *objectId = [NSString randomStringWithLength:5];
@@ -1204,13 +1204,19 @@
                 expect(error).to.beNil();
                 
                 TGComment *comment = comments.firstObject;
+                comment.content = @"bad post!";
                 
-                [Tapglue deleteComment:comment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                [Tapglue updateComment:comment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
                     expect(success).to.beTruthy();
                     expect(error).to.beNil();
                     
-                    [expectation fulfill];
-                }];iter
+                    [Tapglue deleteComment:comment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                        expect(success).to.beTruthy();
+                        expect(error).to.beNil();
+                        
+                        [expectation fulfill];
+                    }];
+                }];
             }];
         }];
     }];

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1146,4 +1146,30 @@
     }];
 }
 
+// [Correct] Retrieve likes on an objectId
+- (void)testRetrieveLikesOnObjectId {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        NSString *objectId = [NSString randomStringWithLength:5];
+        
+        [Tapglue createLikeForObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+            expect(success).to.beTruthy();
+            expect(error).to.beNil();
+            
+            [Tapglue retrieveLikesForObjectWithId:objectId withCompletionBlock:^(NSArray *likes, NSError *error) {
+                expect(likes).toNot.beNil();
+                expect(likes.count).to.equal(1);
+                expect(error).to.beNil();
+                
+                [Tapglue deleteLikeForObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                    expect(success).to.beTruthy();
+                    expect(error).to.beNil();
+                    
+                    [expectation fulfill];
+                }];
+            }];
+        }];
+    }];
+}
+
 @end

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1111,4 +1111,19 @@
     }];
 }
 
+// [Correct] Create a like on an objectId
+- (void)testCreateLikeOnObjectId {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        NSString *objectId = [NSString randomStringWithLength:5];
+        
+        [Tapglue createLikeForObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+            expect(success).to.beTruthy();
+            expect(error).to.beNil();
+            
+            [expectation fulfill];
+        }];
+    }];
+}
+
 @end

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1188,4 +1188,27 @@
     }];
 }
 
+// [Correct] Delete a comment on a custom object
+- (void)testDeleteCommentOnObjectId {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        NSString *objectId = [NSString randomStringWithLength:5];
+        NSString *comment = [NSString randomStringWithLength:10];
+        
+        TGPostComment* objectComment = [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
+            expect(success).to.beTruthy();
+            expect(error).to.beNil();
+            
+            NSLog(@"CommentId = %@", objectComment.objectId);
+            
+            [Tapglue deleteComment:objectComment forObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                expect(success).to.beTruthy();
+                expect(error).to.beNil();
+                
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+
 @end

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1195,7 +1195,7 @@
         NSString *objectId = [NSString randomStringWithLength:5];
         NSString *comment = [NSString randomStringWithLength:10];
         
-        TGPostComment* objectComment = [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
+        TGComment* objectComment = [Tapglue createComment:comment forObjectWithId:objectId withCompletionBlock:^(BOOL success, NSError *error) {
             expect(success).to.beTruthy();
             expect(error).to.beNil();
             

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -1126,4 +1126,24 @@
     }];
 }
 
+// [Correct] Delete a like on an objectId
+- (void)testDeleteLikeOnObjectId {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        NSString *objectId = [NSString randomStringWithLength:5];
+        
+        [Tapglue createLikeForObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+            expect(success).to.beTruthy();
+            expect(error).to.beNil();
+            
+            [Tapglue deleteLikeForObjectWithId:objectId andCompletionBlock:^(BOOL success, NSError *error) {
+                expect(success).to.beTruthy();
+                expect(error).to.beNil();
+                
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+
 @end

--- a/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
@@ -1,5 +1,5 @@
 //
-//  TGPostReactionTests.m
+//  TGReactionTests.m
 //  Tapglue Tests
 //
 //  Created by Martin Stemmle on 08/12/15.
@@ -22,20 +22,20 @@
 #import "TGUser.h"
 #import "TGPost.h"
 #import "TGAttachment.h"
-#import "TGPostReaction+Private.h"
+#import "TGReaction+Private.h"
 #import "TGPostComment.h"
 #import "TGPostLike.h"
 #import "TGModelObject+Private.h"
 #import "TGEvent+RandomTestEvent.h"
 #import "NSDateFormatter+TGISOFormatter.h"
 
-@interface TGPostReactionTests : TGTestCase
+@interface TGReactionTests : TGTestCase
 @property (nonatomic, strong) TGUser *poster;
 @property (nonatomic, strong) TGUser *reader;
 @property (nonatomic, strong) TGPost *post;
 @end
 
-@implementation TGPostReactionTests
+@implementation TGReactionTests
 
 - (void)setUp {
     [super setUp];

--- a/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
@@ -24,7 +24,7 @@
 #import "TGAttachment.h"
 #import "TGReaction+Private.h"
 #import "TGPostComment.h"
-#import "TGPostLike.h"
+#import "TGLike.h"
 #import "TGModelObject+Private.h"
 #import "TGEvent+RandomTestEvent.h"
 #import "NSDateFormatter+TGISOFormatter.h"
@@ -129,7 +129,7 @@
 }
 
 - (void)testInitLikeWithDictionary {
-    TGPostLike *like = [[TGPostLike alloc] initWithDictionary:@{ @"id": @"12743631303647840",
+    TGLike *like = [[TGLike alloc] initWithDictionary:@{ @"id": @"12743631303647840",
                                                                  @"post_id": @"471739965702621007",
                                                                  @"user_id": @"998667",
                                                                  @"created_at": @"2015-06-01T08:44:57.144996856Z",
@@ -147,7 +147,7 @@
 
 
 - (void)testJsonDictionaryForLike {
-    TGPostLike *like = [TGPostLike new];
+    TGLike *like = [TGLike new];
     like.post = self.post;
     like.user = self.reader;
     

--- a/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGPostReactionTests.m
@@ -23,7 +23,7 @@
 #import "TGPost.h"
 #import "TGAttachment.h"
 #import "TGReaction+Private.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGLike.h"
 #import "TGModelObject+Private.h"
 #import "TGEvent+RandomTestEvent.h"
@@ -74,7 +74,7 @@
 
 
 - (void)testInitCommentWithDictionary {
-    TGPostComment *comment = [[TGPostComment alloc] initWithDictionary:@{ @"id": @"12743631303647840",
+    TGComment *comment = [[TGComment alloc] initWithDictionary:@{ @"id": @"12743631303647840",
                                                                          @"post_id": @"471739965702621007",
                                                                          @"user_id": @"998667",
                                                                          @"content": @"Do like.",
@@ -94,7 +94,7 @@
 
 
 - (void)testJsonDictionaryForComment {
-    TGPostComment *comment = [TGPostComment new];
+    TGComment *comment = [TGComment new];
     comment.post = self.post;
     comment.user = self.reader;
     comment.content = @"funny 😀";
@@ -110,7 +110,7 @@
 }
 
 - (void)testLoadDataOnComment {
-    TGPostComment *comment = [TGPostComment new];
+    TGComment *comment = [TGComment new];
     comment.post = self.post;
     comment.user = self.reader;
     comment.content = @"funny 😀";

--- a/Tapglue Tests/Tapglue Tests/TGPostsIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGPostsIntegrationTests.m
@@ -206,7 +206,7 @@
                     expect(comments).toNot.beNil();
                     expect(error).to.beNil();
                     
-                    TGPostComment *comment = comments.firstObject;
+                    TGComment *comment = comments.firstObject;
                     comment.content = @"bad post!";
                     
                     // Update Comment
@@ -254,7 +254,7 @@
                     expect(comments).toNot.beNil();
                     expect(error).to.beNil();
                     
-                    TGPostComment *comment = comments.firstObject;
+                    TGComment *comment = comments.firstObject;
                     comment.content = @"bad post!";
                     
                     // Update Comment

--- a/Tapglue Tests/Tapglue Tests/TGPostsIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGPostsIntegrationTests.m
@@ -302,7 +302,7 @@
                     expect(likes).toNot.beNil();
                     expect(error).to.beNil();
 
-                    TGPostLike *like = likes.firstObject;
+                    TGLike *like = likes.firstObject;
                     expect(like).toNot.beNil();
                 
                     // Delete Like
@@ -344,7 +344,7 @@
                     expect(likes).toNot.beNil();
                     expect(error).to.beNil();
                     
-                    TGPostLike *like = likes.firstObject;
+                    TGLike *like = likes.firstObject;
                     expect(like).toNot.beNil();
                     
                     // Delete Like

--- a/Tapglue Tests/Tapglue Tests/Tapglue+Posts.h
+++ b/Tapglue Tests/Tapglue Tests/Tapglue+Posts.h
@@ -22,7 +22,7 @@
 #import "TGPost.h"
 #import "TGPost+Reactions.h"
 #import "TGAttachment.h"
-#import "TGPostComment.h"
+#import "TGComment.h"
 #import "TGLike.h"
 
 @interface Tapglue (Posts)
@@ -113,7 +113,7 @@
  @param commentContent The content of the comment.
  @param post The Post object that is being commented.
  */
-+ (TGPostComment*)createCommentWithContent:(NSString*)commentContent
++ (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
@@ -123,7 +123,7 @@
  
  @param comment The comment object that is being updated.
  */
-+ (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Deletes a comment on a post.
@@ -131,7 +131,7 @@
  
  @param comment The comment object that is being deleted.
  */
-+ (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Retrieve comments for a post.

--- a/Tapglue Tests/Tapglue Tests/Tapglue+Posts.h
+++ b/Tapglue Tests/Tapglue Tests/Tapglue+Posts.h
@@ -23,7 +23,7 @@
 #import "TGPost+Reactions.h"
 #import "TGAttachment.h"
 #import "TGPostComment.h"
-#import "TGPostLike.h"
+#import "TGLike.h"
 
 @interface Tapglue (Posts)
 
@@ -159,7 +159,7 @@
  
  @param post The post object for which a like is being created.
  */
-+ (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
++ (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
 
 /*!
  @abstract Delete a like for a post.

--- a/Tapglue Tests/Tapglue Tests/Tapglue+Posts.m
+++ b/Tapglue Tests/Tapglue Tests/Tapglue+Posts.m
@@ -109,7 +109,7 @@
 
 #pragma mark - Likes -
 
-+ (TGPostLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (TGLike*)createLikeForPost:(TGPost*)post withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[self postsManager] createLikeForPost:post withCompletionBlock:completionBlock];
 }
 

--- a/Tapglue Tests/Tapglue Tests/Tapglue+Posts.m
+++ b/Tapglue Tests/Tapglue Tests/Tapglue+Posts.m
@@ -82,17 +82,17 @@
 
 #pragma mark - Comments -
 
-+ (TGPostComment*)createCommentWithContent:(NSString*)commentContent
++ (TGComment*)createCommentWithContent:(NSString*)commentContent
                                    forPost:(TGPost*)post
                        withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     return [[self postsManager] createCommentWithContent:commentContent forPost:post withCompletionBlock:completionBlock];
 }
 
-+ (void)updateComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (void)updateComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [[self postsManager] updateComment:comment withCompletionBlock:completionBlock];
 }
 
-+ (void)deleteComment:(TGPostComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
++ (void)deleteComment:(TGComment*)comment withCompletionBlock:(TGSucessCompletionBlock)completionBlock {
     [[self postsManager] deleteComment:comment withCompletionBlock:completionBlock];
 }
 

--- a/Tapglue Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tapglue Tests/Tests.xcodeproj/project.pbxproj
@@ -90,10 +90,10 @@
 		78C6F6481C184586002A2382 /* TGPostsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 78F787E81C17392F00AC1B39 /* TGPostsManager.m */; };
 		78C6F65D1C186B12002A2382 /* TGPostComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGPostComment.m */; };
 		78C6F65E1C186B12002A2382 /* TGPostComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGPostComment.m */; };
-		78C6F65F1C186B12002A2382 /* TGPostLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGPostLike.m */; };
-		78C6F6601C186B12002A2382 /* TGPostLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGPostLike.m */; };
-		78C6F6611C186B12002A2382 /* TGPostReaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65C1C186B12002A2382 /* TGPostReaction.m */; };
-		78C6F6621C186B12002A2382 /* TGPostReaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65C1C186B12002A2382 /* TGPostReaction.m */; };
+		78C6F65F1C186B12002A2382 /* TGLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGLike.m */; };
+		78C6F6601C186B12002A2382 /* TGLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGLike.m */; };
+		78C6F6611C186B12002A2382 /* TGReaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65C1C186B12002A2382 /* TGReaction.m */; };
+		78C6F6621C186B12002A2382 /* TGReaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65C1C186B12002A2382 /* TGReaction.m */; };
 		78C6F6641C186B83002A2382 /* TGPostReactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6631C186B83002A2382 /* TGPostReactionTests.m */; };
 		78CF3D5E1B25CCAF0091B81B /* NSArray+RandomObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 78CF3D5D1B25CCAF0091B81B /* NSArray+RandomObject.m */; };
 		78CF3D611B25CFF30091B81B /* TGEvent+RandomTestEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 78CF3D601B25CFF30091B81B /* TGEvent+RandomTestEvent.m */; };
@@ -200,12 +200,12 @@
 		78C6F6441C182FC6002A2382 /* TGApiRoutesBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGApiRoutesBuilder.m; sourceTree = "<group>"; };
 		78C6F6571C186B12002A2382 /* TGPostComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGPostComment.h; path = ../../Classes/Model/TGPostComment.h; sourceTree = "<group>"; };
 		78C6F6581C186B12002A2382 /* TGPostComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGPostComment.m; path = ../../Classes/Model/TGPostComment.m; sourceTree = "<group>"; };
-		78C6F6591C186B12002A2382 /* TGPostLike.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGPostLike.h; path = ../../Classes/Model/TGPostLike.h; sourceTree = "<group>"; };
-		78C6F65A1C186B12002A2382 /* TGPostLike.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGPostLike.m; path = ../../Classes/Model/TGPostLike.m; sourceTree = "<group>"; };
-		78C6F65B1C186B12002A2382 /* TGPostReaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGPostReaction.h; path = ../../Classes/Model/TGPostReaction.h; sourceTree = "<group>"; };
-		78C6F65C1C186B12002A2382 /* TGPostReaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGPostReaction.m; path = ../../Classes/Model/TGPostReaction.m; sourceTree = "<group>"; };
+		78C6F6591C186B12002A2382 /* TGLike.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGLike.h; path = ../../Classes/Model/TGLike.h; sourceTree = "<group>"; };
+		78C6F65A1C186B12002A2382 /* TGLike.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGLike.m; path = ../../Classes/Model/TGLike.m; sourceTree = "<group>"; };
+		78C6F65B1C186B12002A2382 /* TGReaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGReaction.h; path = ../../Classes/Model/TGReaction.h; sourceTree = "<group>"; };
+		78C6F65C1C186B12002A2382 /* TGReaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGReaction.m; path = ../../Classes/Model/TGReaction.m; sourceTree = "<group>"; };
 		78C6F6631C186B83002A2382 /* TGPostReactionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGPostReactionTests.m; sourceTree = "<group>"; };
-		78C6F66A1C18757E002A2382 /* TGPostReaction+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TGPostReaction+Private.h"; path = "../../Classes/Model/TGPostReaction+Private.h"; sourceTree = "<group>"; };
+		78C6F66A1C18757E002A2382 /* TGReaction+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TGReaction+Private.h"; path = "../../Classes/Model/TGReaction+Private.h"; sourceTree = "<group>"; };
 		78CC3E9B1C18997000190616 /* TGApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGApiClientTests.m; sourceTree = "<group>"; };
 		78CF3D5C1B25CCAF0091B81B /* NSArray+RandomObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RandomObject.h"; sourceTree = "<group>"; };
 		78CF3D5D1B25CCAF0091B81B /* NSArray+RandomObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RandomObject.m"; sourceTree = "<group>"; };
@@ -457,13 +457,13 @@
 				789E19161C171B8800192EE4 /* TGAttachment.h */,
 				78F787E01C1724FA00AC1B39 /* TGAttachment+Private.h */,
 				789E19171C171B8800192EE4 /* TGAttachment.m */,
-				78C6F65B1C186B12002A2382 /* TGPostReaction.h */,
-				78C6F65C1C186B12002A2382 /* TGPostReaction.m */,
-				78C6F66A1C18757E002A2382 /* TGPostReaction+Private.h */,
+				78C6F65B1C186B12002A2382 /* TGReaction.h */,
+				78C6F65C1C186B12002A2382 /* TGReaction.m */,
+				78C6F66A1C18757E002A2382 /* TGReaction+Private.h */,
 				78C6F6571C186B12002A2382 /* TGPostComment.h */,
 				78C6F6581C186B12002A2382 /* TGPostComment.m */,
-				78C6F6591C186B12002A2382 /* TGPostLike.h */,
-				78C6F65A1C186B12002A2382 /* TGPostLike.m */,
+				78C6F6591C186B12002A2382 /* TGLike.h */,
+				78C6F65A1C186B12002A2382 /* TGLike.m */,
 				78E036671C18BB5E00AF53FA /* TGPost+Reactions.h */,
 				78E036681C18BB5E00AF53FA /* TGPost+Reactions.m */,
 			);
@@ -675,7 +675,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78F787ED1C1739B000AC1B39 /* Tapglue+Posts.m in Sources */,
-				78C6F6621C186B12002A2382 /* TGPostReaction.m in Sources */,
+				78C6F6621C186B12002A2382 /* TGReaction.m in Sources */,
 				78F787DF1C1722CB00AC1B39 /* TGAttachment.m in Sources */,
 				9767716A1C188A3900F5333C /* TGPostsIntegrationTests.m in Sources */,
 				783185F41BBAD07E0050F9DB /* TGImage.m in Sources */,
@@ -697,7 +697,7 @@
 				7878EC851B2B24D900BA47F6 /* NSString+TGUtilities.m in Sources */,
 				789E19101C16E41100192EE4 /* TGQuery.m in Sources */,
 				78C6F65E1C186B12002A2382 /* TGPostComment.m in Sources */,
-				78C6F6601C186B12002A2382 /* TGPostLike.m in Sources */,
+				78C6F6601C186B12002A2382 /* TGLike.m in Sources */,
 				7892F2771C18CA85008B57DF /* TGPost+Reactions.m in Sources */,
 				7878EC861B2B24D900BA47F6 /* TGEvent+RandomTestEvent.m in Sources */,
 				7878EC871B2B24D900BA47F6 /* NSURL+TGUtilities.m in Sources */,
@@ -751,7 +751,7 @@
 				78F787E91C17392F00AC1B39 /* TGPostsManager.m in Sources */,
 				78C6D15A1B1DA4CF00D94E6A /* NSURL+TGUtilities.m in Sources */,
 				7878ECAC1B2B279500BA47F6 /* TGApiClientMock.m in Sources */,
-				78C6F65F1C186B12002A2382 /* TGPostLike.m in Sources */,
+				78C6F65F1C186B12002A2382 /* TGLike.m in Sources */,
 				78D7366A1B1F60D000BE194D /* TGEventObjectTests.m in Sources */,
 				78AA607D1C15CB2F007F56D5 /* TGQueryTests.m in Sources */,
 				97285B421B1F4AFA00D4CAC7 /* TGEventObject.m in Sources */,
@@ -774,7 +774,7 @@
 				788DBF8D1B21E6E40058C1C2 /* TGSetupTests.m in Sources */,
 				78DBCC5F1B20893B009986BA /* NSDictionary+TGUtilities.m in Sources */,
 				7866BFAF1C1886BA00F28FCA /* TGApiClient+TGObject.m in Sources */,
-				78C6F6611C186B12002A2382 /* TGPostReaction.m in Sources */,
+				78C6F6611C186B12002A2382 /* TGReaction.m in Sources */,
 				78CF3D5E1B25CCAF0091B81B /* NSArray+RandomObject.m in Sources */,
 				78AA609C1C15F47E007F56D5 /* TGConnectionTests.m in Sources */,
 				78AA60931C15D9E1007F56D5 /* TGQuery.m in Sources */,

--- a/Tapglue Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tapglue Tests/Tests.xcodeproj/project.pbxproj
@@ -88,8 +88,8 @@
 		78C6F6461C182FCB002A2382 /* TGApiRoutesBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6441C182FC6002A2382 /* TGApiRoutesBuilder.m */; };
 		78C6F6471C1843BE002A2382 /* TGPost.m in Sources */ = {isa = PBXBuildFile; fileRef = 789E19121C17122F00192EE4 /* TGPost.m */; };
 		78C6F6481C184586002A2382 /* TGPostsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 78F787E81C17392F00AC1B39 /* TGPostsManager.m */; };
-		78C6F65D1C186B12002A2382 /* TGPostComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGPostComment.m */; };
-		78C6F65E1C186B12002A2382 /* TGPostComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGPostComment.m */; };
+		78C6F65D1C186B12002A2382 /* TGComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGComment.m */; };
+		78C6F65E1C186B12002A2382 /* TGComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F6581C186B12002A2382 /* TGComment.m */; };
 		78C6F65F1C186B12002A2382 /* TGLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGLike.m */; };
 		78C6F6601C186B12002A2382 /* TGLike.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65A1C186B12002A2382 /* TGLike.m */; };
 		78C6F6611C186B12002A2382 /* TGReaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C6F65C1C186B12002A2382 /* TGReaction.m */; };
@@ -198,8 +198,8 @@
 		78C6D1641B1DBE2100D94E6A /* NSString+TGUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+TGUtilities.m"; sourceTree = "<group>"; };
 		78C6F6431C182FC6002A2382 /* TGApiRoutesBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TGApiRoutesBuilder.h; sourceTree = "<group>"; };
 		78C6F6441C182FC6002A2382 /* TGApiRoutesBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGApiRoutesBuilder.m; sourceTree = "<group>"; };
-		78C6F6571C186B12002A2382 /* TGPostComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGPostComment.h; path = ../../Classes/Model/TGPostComment.h; sourceTree = "<group>"; };
-		78C6F6581C186B12002A2382 /* TGPostComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGPostComment.m; path = ../../Classes/Model/TGPostComment.m; sourceTree = "<group>"; };
+		78C6F6571C186B12002A2382 /* TGComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGComment.h; path = ../../Classes/Model/TGComment.h; sourceTree = "<group>"; };
+		78C6F6581C186B12002A2382 /* TGComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGComment.m; path = ../../Classes/Model/TGComment.m; sourceTree = "<group>"; };
 		78C6F6591C186B12002A2382 /* TGLike.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGLike.h; path = ../../Classes/Model/TGLike.h; sourceTree = "<group>"; };
 		78C6F65A1C186B12002A2382 /* TGLike.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TGLike.m; path = ../../Classes/Model/TGLike.m; sourceTree = "<group>"; };
 		78C6F65B1C186B12002A2382 /* TGReaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGReaction.h; path = ../../Classes/Model/TGReaction.h; sourceTree = "<group>"; };
@@ -460,8 +460,8 @@
 				78C6F65B1C186B12002A2382 /* TGReaction.h */,
 				78C6F65C1C186B12002A2382 /* TGReaction.m */,
 				78C6F66A1C18757E002A2382 /* TGReaction+Private.h */,
-				78C6F6571C186B12002A2382 /* TGPostComment.h */,
-				78C6F6581C186B12002A2382 /* TGPostComment.m */,
+				78C6F6571C186B12002A2382 /* TGComment.h */,
+				78C6F6581C186B12002A2382 /* TGComment.m */,
 				78C6F6591C186B12002A2382 /* TGLike.h */,
 				78C6F65A1C186B12002A2382 /* TGLike.m */,
 				78E036671C18BB5E00AF53FA /* TGPost+Reactions.h */,
@@ -696,7 +696,7 @@
 				7878EC841B2B24D900BA47F6 /* UIDevice+TGUtilities.m in Sources */,
 				7878EC851B2B24D900BA47F6 /* NSString+TGUtilities.m in Sources */,
 				789E19101C16E41100192EE4 /* TGQuery.m in Sources */,
-				78C6F65E1C186B12002A2382 /* TGPostComment.m in Sources */,
+				78C6F65E1C186B12002A2382 /* TGComment.m in Sources */,
 				78C6F6601C186B12002A2382 /* TGLike.m in Sources */,
 				7892F2771C18CA85008B57DF /* TGPost+Reactions.m in Sources */,
 				7878EC861B2B24D900BA47F6 /* TGEvent+RandomTestEvent.m in Sources */,
@@ -755,7 +755,7 @@
 				78D7366A1B1F60D000BE194D /* TGEventObjectTests.m in Sources */,
 				78AA607D1C15CB2F007F56D5 /* TGQueryTests.m in Sources */,
 				97285B421B1F4AFA00D4CAC7 /* TGEventObject.m in Sources */,
-				78C6F65D1C186B12002A2382 /* TGPostComment.m in Sources */,
+				78C6F65D1C186B12002A2382 /* TGComment.m in Sources */,
 				78C34FA71B26F8DD00286D78 /* EXPMatchers+beKindOfOrNil.m in Sources */,
 				788DBF8B1B21D4870058C1C2 /* TGBaseManager.m in Sources */,
 				78DBCC621B20AD23009986BA /* TGEventManager.m in Sources */,


### PR DESCRIPTION
Implement comments and likes on external objects.

### API

We going to provide a new set of routes which at their roots share `/externals` and offer the same functionality that can be found for `/posts`. Instead of expecting a post id we offer a that a set of alphanumeric characters can be passed which is used to associate the entity created with it for later reference and list retrieval.

```
/externals/{externalID:[a-zA-Z0-9]+}/comments
/externals/{externalID:[a-zA-Z0-9]+}/likes
...
```

To offer the same convenience that we have for Posts (e.g. Counts) for external objects we going to serve a limited response for `/externals/:id`.

```
"counts": {
  "comments": 3,
  "likes": 12,
  "shares": 1
},
"id": "1a2b7c4d3e6f3g1h3i0j3k6l4m7n8o3p9q"
```

Another assumption which doesn't hold true is the knowledge around `Visibility` which means that we have to force the caller to provide that information.

```
curl -X POST /externals/1a2b7c4d3e6f3g1h3i0j3k6l4m7n8o3p9q/comments \
    -d $'
    {
        "content": "Do like.",
        "visibility": 30
    }
    '
```

```
201 Created
{
  "content": "Do like.",
  "external_id": "1a2b7c4d3e6f3g1h3i0j3k6l4m7n8o3p9q",
  "id": "12743631303647840",
  "user_id": "11286878691041888",
  "visibility": 30,
  "created_at": "2015-11-27T16:03:36.171840385Z",
  "updated_at": "2015-11-27T16:03:36.171840478Z"
}
```

```
curl -X POST /externals/1a2b7c4d3e6f3g1h3i0j3k6l4m7n8o3p9q/like \
    -d $'
    {
      "visibility": 30
    }
    '
```

```
201 Created
{
  "external_id": "1a2b7c4d3e6f3g1h3i0j3k6l4m7n8o3p9q",
  "id": "37363583381716140",
  "user_id": "11286878691041888",
  "created_at":"2015-03-21T14:28:02.4+01:00",
  "updated_at":"2015-03-21T14:28:02.4+01:00"
}
```
