### PR TITLE
User recommendations

### DIFF
--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -85,6 +85,6 @@
 
 #pragma mark - User recommendations
 
-+ (NSString*)routeForUserRecommendationsActive;
++ (NSString*)routeForUserRecommendationsOfType:(NSString*)type andPeriod:(NSString*)period;
 
 @end

--- a/Classes/RestClient/TGApiRoutesBuilder.h
+++ b/Classes/RestClient/TGApiRoutesBuilder.h
@@ -83,4 +83,8 @@
 
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId;
 
+#pragma mark - User recommendations
+
++ (NSString*)routeForUserRecommendationsActive;
+
 @end

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -30,6 +30,8 @@ static NSString * const TGApiRoutePosts = @"posts";
 static NSString * const TGApiRouteEvents = @"events";
 static NSString * const TGApiRouteComments = @"comments";
 static NSString * const TGApiRouteLikes = @"likes";
+static NSString * const TGApiRouteRecommendations = @"recommendations";
+static NSString * const TGApiRouteRecommendationsActive = @"active";
 
 @implementation TGApiRoutesBuilder
 
@@ -98,6 +100,12 @@ static NSString * const TGApiRouteLikes = @"likes";
 + (NSString*)routeForLikeWithId:(NSString*)likeId onPostWithId:(NSString*)postId {
     NSParameterAssert(likeId);
     return [[self routeForLikesOnPostWithId:postId] stringByAppendingPathComponent:likeId];
+}
+
+#pragma mark - User recommendations
+
++ (NSString*)routeForUserRecommendationsActive {
+    return [TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteRecommendationsActive];
 }
 
 #pragma mark - Helper 

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -32,7 +32,6 @@ static NSString * const TGApiRouteEvents = @"events";
 static NSString * const TGApiRouteComments = @"comments";
 static NSString * const TGApiRouteLikes = @"likes";
 static NSString * const TGApiRouteRecommendations = @"recommendations";
-static NSString * const TGApiRouteRecommendationsActive = @"active";
 
 @implementation TGApiRoutesBuilder
 
@@ -108,10 +107,10 @@ static NSString * const TGApiRouteRecommendationsActive = @"active";
 + (NSString*)routeForUserRecommendationsOfType:(NSString*)type andPeriod:(NSString*)period {
     //TODO: Rewrite to Switch-Case
     if (type == TGUserRecommendationsTypeActive) {
-        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:TGApiRouteRecommendationsActive] stringByAppendingPathComponent:period];
+        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:type] stringByAppendingPathComponent:period];
     } else {
         // Default behaviour is to retrieve the most active users
-        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:TGApiRouteRecommendationsActive] stringByAppendingPathComponent:period];
+        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:type] stringByAppendingPathComponent:period];
     }
 }
 

--- a/Classes/RestClient/TGApiRoutesBuilder.m
+++ b/Classes/RestClient/TGApiRoutesBuilder.m
@@ -22,6 +22,7 @@
 #import "TGPost.h"
 #import "TGPostComment.h"
 #import "TGPostLike.h"
+#import "TGConstants.h"
 
 static NSString * const TGApiRouteUsers = @"users";
 static NSString * const TGApiRouteCurrentUser = @"me";
@@ -104,8 +105,14 @@ static NSString * const TGApiRouteRecommendationsActive = @"active";
 
 #pragma mark - User recommendations
 
-+ (NSString*)routeForUserRecommendationsActive {
-    return [TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteRecommendationsActive];
++ (NSString*)routeForUserRecommendationsOfType:(NSString*)type andPeriod:(NSString*)period {
+    //TODO: Rewrite to Switch-Case
+    if (type == TGUserRecommendationsTypeActive) {
+        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:TGApiRouteRecommendationsActive] stringByAppendingPathComponent:period];
+    } else {
+        // Default behaviour is to retrieve the most active users
+        return [[[TGApiRouteRecommendations stringByAppendingPathComponent:TGApiRouteUsers] stringByAppendingPathComponent:TGApiRouteRecommendationsActive] stringByAppendingPathComponent:period];
+    }
 }
 
 #pragma mark - Helper 

--- a/Classes/TGConstants.h
+++ b/Classes/TGConstants.h
@@ -59,31 +59,51 @@ static NSString *const TGPlatformKeyGoogle = @"google";
  */
 static NSString *const TGPlatformKeyCustom = @"custom";
 
-#pragma mark - Recommendation Parameters
+#pragma mark - Recommendation Types
 
 /*!
  @abstract Defines the Type of the Latest User Recommendation.
- @constant TGUserRecommendationsActive holds the key for for recommending latest users.
+ @constant TGUserRecommendationsTypeLatest holds the key for recommending latest users.
  */
-static NSString *const TGUserRecommendationsLatest = @"latest";
+static NSString *const TGUserRecommendationsTypeLatest = @"latest";
 
 /*!
  @abstract Defines the Type of the Trending User Recommendation.
- @constant TGUserRecommendationsActive holds the key for for recommending trending users.
+ @constant TGUserRecommendationsTypeTrending holds the key for recommending trending users.
  */
-static NSString *const TGUserRecommendationsTrending = @"trending";
+static NSString *const TGUserRecommendationsTypeTrending = @"trending";
 
 /*!
  @abstract Defines the Type of the Active User Recommendation.
- @constant TGUserRecommendationsActive holds the key for for recommending active users.
+ @constant TGUserRecommendationsTypeActive holds the key for recommending active users.
  */
-static NSString *const TGUserRecommendationsActive = @"active";
+static NSString *const TGUserRecommendationsTypeActive = @"active";
 
 /*!
  @abstract Defines the Type of the Random User Recommendation.
- @constant TGUserRecommendationsActive holds the key for for recommending random users.
+ @constant TGUserRecommendationsTypeRandom holds the key for recommending random users.
  */
-static NSString *const TGUserRecommendationsRandom = @"random";
+static NSString *const TGUserRecommendationsTypeRandom = @"random";
+
+#pragma mark - Recommendation periods
+
+/*!
+ @abstract Defines the Period of the User Recommendation for a day.
+ @constant TGUserRecommendationsPeriodDay holds the key for user recommendations for a day.
+ */
+static NSString *const TGUserRecommendationsPeriodDay = @"day";
+
+/*!
+ @abstract Defines the Period of the User Recommendation for a week.
+ @constant TGUserRecommendationsPeriodWeek holds the key for user recommendations for a week.
+ */
+static NSString *const TGUserRecommendationsPeriodWeek = @"week";
+
+/*!
+ @abstract Defines the Type of the Active User Recommendation.
+ @constant TGUserRecommendationsPeriodMonth holds the key for user recommendations for a month.
+ */
+static NSString *const TGUserRecommendationsPeriodMonth = @"month";
 
 #pragma mark - Errors
 

--- a/Classes/TGConstants.h
+++ b/Classes/TGConstants.h
@@ -62,28 +62,10 @@ static NSString *const TGPlatformKeyCustom = @"custom";
 #pragma mark - Recommendation Types
 
 /*!
- @abstract Defines the Type of the Latest User Recommendation.
- @constant TGUserRecommendationsTypeLatest holds the key for recommending latest users.
- */
-static NSString *const TGUserRecommendationsTypeLatest = @"latest";
-
-/*!
- @abstract Defines the Type of the Trending User Recommendation.
- @constant TGUserRecommendationsTypeTrending holds the key for recommending trending users.
- */
-static NSString *const TGUserRecommendationsTypeTrending = @"trending";
-
-/*!
  @abstract Defines the Type of the Active User Recommendation.
  @constant TGUserRecommendationsTypeActive holds the key for recommending active users.
  */
 static NSString *const TGUserRecommendationsTypeActive = @"active";
-
-/*!
- @abstract Defines the Type of the Random User Recommendation.
- @constant TGUserRecommendationsTypeRandom holds the key for recommending random users.
- */
-static NSString *const TGUserRecommendationsTypeRandom = @"random";
 
 #pragma mark - Recommendation periods
 

--- a/Classes/TGConstants.h
+++ b/Classes/TGConstants.h
@@ -59,6 +59,31 @@ static NSString *const TGPlatformKeyGoogle = @"google";
  */
 static NSString *const TGPlatformKeyCustom = @"custom";
 
+#pragma mark - Recommendation Parameters
+
+/*!
+ @abstract Defines the Type of the Latest User Recommendation.
+ @constant TGUserRecommendationsActive holds the key for for recommending latest users.
+ */
+static NSString *const TGUserRecommendationsLatest = @"latest";
+
+/*!
+ @abstract Defines the Type of the Trending User Recommendation.
+ @constant TGUserRecommendationsActive holds the key for for recommending trending users.
+ */
+static NSString *const TGUserRecommendationsTrending = @"trending";
+
+/*!
+ @abstract Defines the Type of the Active User Recommendation.
+ @constant TGUserRecommendationsActive holds the key for for recommending active users.
+ */
+static NSString *const TGUserRecommendationsActive = @"active";
+
+/*!
+ @abstract Defines the Type of the Random User Recommendation.
+ @constant TGUserRecommendationsActive holds the key for for recommending random users.
+ */
+static NSString *const TGUserRecommendationsRandom = @"random";
 
 #pragma mark - Errors
 

--- a/Classes/TGUserManager.h
+++ b/Classes/TGUserManager.h
@@ -214,5 +214,15 @@ typedef NS_ENUM(NSUInteger, TGConnectionType) {
                                                                 ofType:(TGConnectionType)connectionType
                                                       toSocialUsersIds:(NSArray*)toSocialUsersIds
                                                    withCompletionBlock:(TGSucessCompletionBlock)completionBlock;
+#pragma mark - Recommendations
+
+/*!
+ @abstract Retrieve user recommendatons.
+ @discussion This will retrieve user recommendations based on a type and period.
+ 
+ @param type Type of user recommendation that is being retrieved.
+ @param period Period of user recommendations.
+ */
+- (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(TGGetUserListCompletionBlock)completionBlock;
 
 @end

--- a/Classes/TGUserManager.m
+++ b/Classes/TGUserManager.m
@@ -27,6 +27,7 @@
 #import "NSError+TGError.h"
 #import "TGObjectCache.h"
 #import "TGConnection+Private.h"
+#import "TGAPIRoutesBuilder.h"
 
 NSString *const TapglueUserDefaultsKeySessionToken = @"sessionToken";
 NSString *const TGUserManagerAPIEndpointCurrentUser = @"me";
@@ -366,6 +367,15 @@ static NSString *const TGUserManagerAPIEndpointConnections = @"me/connections";
     route = [route stringByAppendingPathComponent:[self stringFromConnectionType:connectionType]];
     route = [route stringByAppendingPathComponent:toUser.userId];
     [self.client DELETE:route withURLParameters:nil andCompletionBlock:completionBlock];
+}
+
+#pragma mark - Recommendations
+
+- (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(TGGetUserListCompletionBlock)completionBlock {
+    NSString *route = [TGApiRoutesBuilder routeForUserRecommendationsOfType:type andPeriod:period];
+    [self.client GET:route withCompletionBlock:^(NSDictionary *jsonResponse, NSError *error) {
+        [self handleUserListResponse:jsonResponse withError:error andCompletionBlock:completionBlock];
+    }];
 }
 
 #pragma mark - Helper

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -556,6 +556,15 @@
  */
 + (void)retrieveNewsFeedForCurrentUserForEventTypes:(NSArray*)types withCompletionBlock:(TGGetNewsFeedCompletionBlock)completionBlock;
 
+/*!
+ @abstract Retrieve user recommendations.
+ @discussion This will retrieve recommended users for the current user.
+ 
+ @param type The type of the user recommendation (latest, trending, active, random).
+ @param period The period the user recommendations are fetched for.
+ */
++ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock;
+
 #pragma mark - Raw Rest -
 
 /*!

--- a/Classes/Tapglue.h
+++ b/Classes/Tapglue.h
@@ -413,7 +413,23 @@
  */
 + (void)retrieveEventsForCurrentUserWithCompletionBlock:(void (^)(NSArray *events, NSError *error))completionBlock;
 
+#pragma mark - User Recommendations
 
+/*!
+ @abstract Retrieve user recommendations.
+ @discussion This will retrieve recommended users for the current user.
+ 
+ @param type The type of the user recommendation (latest, trending, active, random).
+ @param period The period the user recommendations are fetched for.
+ */
++ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock;
+
+/*!
+ @abstract Retrieve user recommendations.
+ @discussion This will retrieve recommended active users for the current user for a period day.
+ */
++ (void)retrieveUserRecommendationsWithCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock;
+ 
 #pragma mark - Feeds
 
 /*!
@@ -555,15 +571,6 @@
  @discussion This will retrieve a news feed for a set of event types.
  */
 + (void)retrieveNewsFeedForCurrentUserForEventTypes:(NSArray*)types withCompletionBlock:(TGGetNewsFeedCompletionBlock)completionBlock;
-
-/*!
- @abstract Retrieve user recommendations.
- @discussion This will retrieve recommended users for the current user.
- 
- @param type The type of the user recommendation (latest, trending, active, random).
- @param period The period the user recommendations are fetched for.
- */
-+ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock;
 
 #pragma mark - Raw Rest -
 

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -598,6 +598,10 @@ static Tapglue* sharedInstance = nil;
     [[self sharedInstance].eventManager retrieveNewsFeedForCurrentUserWithQuery:query andCompletionBlock:completionBlock];
 }
 
++ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock {
+    // TODO:
+}
+
 #pragma mark - Raw Rest -
 
 + (NSURLSessionDataTask*) makeRestRequestWithHTTPMethod:(NSString*)method

--- a/Classes/Tapglue.m
+++ b/Classes/Tapglue.m
@@ -31,6 +31,7 @@
 #import "TGUserManager.h"
 #import "TGObjectCache.h"
 #import "TGConfiguration.h"
+#import "TGConstants.h"
 
 #import <UIKit/UIKit.h>
 
@@ -288,6 +289,16 @@ static Tapglue* sharedInstance = nil;
                  withSocialUsersIds:(NSArray*)socialUserIds
                  andCompletionBlock:(TGGetUserListCompletionBlock)completionBlock {
     [[self sharedInstance].userManager searchUsersOnSocialPlatform:socialPlatform withSocialUsersIds:socialUserIds andCompletionBlock:completionBlock];
+}
+
+#pragma mark - User Recommendations
+
++ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock {
+    [[self sharedInstance].userManager retrieveUserRecommendationsOfType:type forPeriod:period andCompletionBlock:completionBlock];
+}
+
++ (void)retrieveUserRecommendationsWithCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock {
+    [[self sharedInstance].userManager retrieveUserRecommendationsOfType:TGUserRecommendationsTypeActive forPeriod:TGUserRecommendationsPeriodDay andCompletionBlock:completionBlock];
 }
 
 #pragma mark - Feed
@@ -596,10 +607,6 @@ static Tapglue* sharedInstance = nil;
 + (void)retrieveNewsFeedForCurrentUserForEventTypes:(NSArray*)types withCompletionBlock:(TGGetNewsFeedCompletionBlock)completionBlock {
     TGQuery * query = [[self sharedInstance].eventManager composeQueryForEventTypes:types];
     [[self sharedInstance].eventManager retrieveNewsFeedForCurrentUserWithQuery:query andCompletionBlock:completionBlock];
-}
-
-+ (void)retrieveUserRecommendationsOfType:(NSString*)type forPeriod:(NSString*)period andCompletionBlock:(void (^)(NSArray *users, NSError *error))completionBlock {
-    // TODO:
 }
 
 #pragma mark - Raw Rest -

--- a/Tapglue Tests/Tapglue Tests/TGUserIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGUserIntegrationTests.m
@@ -1106,4 +1106,29 @@
     }];
 }
 
+#pragma mark - User Recommendation Tests -
+// [Correct] Retrieve user recommendations
+- (void)testRetrieveUserRecommendations {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        [Tapglue retrieveUserRecommendationsOfType:TGUserRecommendationsTypeActive forPeriod:TGUserRecommendationsPeriodDay andCompletionBlock:^(NSArray *users, NSError *error) {
+            expect(users).toNot.beNil();
+            expect(error).to.beNil();
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// [Correct] Retrieve user recommendations convenience
+- (void)testRetrieveUserRecommendationsConvenient {
+    [self runTestBlockAfterLogin:^(XCTestExpectation *expectation) {
+        
+        [Tapglue retrieveUserRecommendationsWithCompletionBlock:^(NSArray *users, NSError *error) {
+            expect(users).toNot.beNil();
+            expect(error).to.beNil();
+            [expectation fulfill];
+        }];
+    }];
+}
+
 @end


### PR DESCRIPTION
# User suggestions

Before building a fully-fledged user recommendations API we discussed building a simple heuristic which provides a list of users as a suggestion to another user. The main use-case would be to show list of users to another user during the Onboarding to the community.

# Goal

The goal is to overcome the empty-room-problem by providing features to the customers that help to grow their network fast.