### PR TITLE
Fix users parsed after posts

### DIFF
--- a/Classes/TGEventManager.m
+++ b/Classes/TGEventManager.m
@@ -506,15 +506,15 @@ NSDictionary* typesWithPost;
 }
 
 - (NSArray*)eventsFromJsonResponse:(NSDictionary*)jsonResponse {
-    NSDictionary *postDictionaries = [jsonResponse objectForKey:@"post_map"];
-    
-    for(NSDictionary *postData in postDictionaries) {
-        [TGPost createOrLoadWithDictionary:postDictionaries[postData]];
-    }
     
     NSDictionary *userDictionaries = [jsonResponse objectForKey:@"users"];
     for(NSDictionary *userData in userDictionaries) {
         [TGUser createOrLoadWithDictionary:userDictionaries[userData]];
+    }
+    
+    NSDictionary *postDictionaries = [jsonResponse objectForKey:@"post_map"];
+    for(NSDictionary *postData in postDictionaries) {
+        [TGPost createOrLoadWithDictionary:postDictionaries[postData]];
     }
     
     NSArray *eventDictionaries = [jsonResponse objectForKey:@"events"];

--- a/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
+++ b/Tapglue Tests/Tapglue Tests/TGEventIntegrationTests.m
@@ -370,6 +370,7 @@
                     expect(events.count).to.equal(1);
                     TGEvent* event = events[0];
                     expect(event.post.objectId).to.equal(post.objectId);
+                    expect(event.post.user.userId).to.equal(post.user.userId);
                     
                     for(TGEvent* event in events) {
                         [Tapglue deleteEventWithId:event.eventId withCompletionBlock:^(BOOL success, NSError *error) {


### PR DESCRIPTION
When posts are parsed they check users from already cached results, therefore in the current implementation we need to parse and cache users before we parse posts.